### PR TITLE
Fix Loggi Order `originalEta` field not being handled correctly

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    loggi (0.4.0)
+    loggi (0.5.0)
       activesupport (~> 5.0)
       http (~> 4.1.1)
 

--- a/lib/loggi/order.rb
+++ b/lib/loggi/order.rb
@@ -25,7 +25,7 @@ module Loggi
       @pk = options[:pk]
       @status = options[:status]
       @status_display = options[:status_display] || options[:statusDisplay]
-      @original_eta = options[:original_eta] || options[:originalETA]
+      @original_eta = options[:original_eta] || options[:originalEta]
       @total_time = options[:total_time] || options[:totalTime]
       @pricing = build_nested(options, %i[pricing], OrderPricing)
       @current_driver_position = build_nested(options,

--- a/lib/loggi/version.rb
+++ b/lib/loggi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Loggi
-  VERSION = '0.4.0'
+  VERSION = '0.5.0'
 end

--- a/spec/lib/loggi/order_spec.rb
+++ b/spec/lib/loggi/order_spec.rb
@@ -18,28 +18,57 @@ RSpec.describe Loggi::Order, type: :model do
         let(:packages) { build_list :package, 1 }
         let(:pricing) { build :order_pricing }
         let(:current_driver_position) { build :driver_position }
-        let(:options) do
-          {
-            pk: 10,
-            packages: packages,
-            pricing: pricing,
-            current_driver_position: current_driver_position,
-            status: 'allocating',
-            status_display: 'Em alocação',
-            original_eta: 2033,
-            total_time: nil
-          }
+
+        context 'with correct fields' do
+          let(:options) do
+            {
+              pk: 10,
+              packages: packages,
+              pricing: pricing,
+              current_driver_position: current_driver_position,
+              status: 'allocating',
+              status_display: 'Em alocação',
+              original_eta: 2033,
+              total_time: nil
+            }
+          end
+
+          it 'should full all fields' do
+            expect(subject.pk).to eq(10)
+            expect(subject.packages.all? { |package| package.is_a?(Loggi::Package) }).to be_truthy
+            expect(subject.pricing).to eq(pricing)
+            expect(subject.current_driver_position).to eq(current_driver_position)
+            expect(subject.status).to eq('allocating')
+            expect(subject.status_display).to eq('Em alocação')
+            expect(subject.original_eta).to eq(2033)
+            expect(subject.total_time).to eq(nil)
+          end
         end
 
-        it 'should full all fields' do
-          expect(subject.pk).to eq(10)
-          expect(subject.packages.all? { |package| package.is_a?(Loggi::Package) }).to be_truthy
-          expect(subject.pricing).to eq(pricing)
-          expect(subject.current_driver_position).to eq(current_driver_position)
-          expect(subject.status).to eq('allocating')
-          expect(subject.status_display).to eq('Em alocação')
-          expect(subject.original_eta).to eq(2033)
-          expect(subject.total_time).to eq(nil)
+        context 'with alternated fields' do
+          let(:options) do
+            {
+              pk: 10,
+              packages: packages,
+              pricing: pricing,
+              currentDriverPosition: current_driver_position,
+              status: 'allocating',
+              statusDisplay: 'Em alocação',
+              originalEta: 2033,
+              totalTime: nil
+            }
+          end
+
+          it 'should full all fields' do
+            expect(subject.pk).to eq(10)
+            expect(subject.packages.all? { |package| package.is_a?(Loggi::Package) }).to be_truthy
+            expect(subject.pricing).to eq(pricing)
+            expect(subject.current_driver_position).to eq(current_driver_position)
+            expect(subject.status).to eq('allocating')
+            expect(subject.status_display).to eq('Em alocação')
+            expect(subject.original_eta).to eq(2033)
+            expect(subject.total_time).to eq(nil)
+          end
         end
       end
 


### PR DESCRIPTION
Muda o campo esperado de `originalETA` para `originalEta` que é o campo correto devolvido pela Loggi.