### PR TITLE
Fix time parsing in wrong timezone [check ci]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    loggi (0.5.0)
+    loggi (0.6.0)
       activesupport (~> 5.0)
       http (~> 4.1.1)
 

--- a/lib/loggi/package_status.rb
+++ b/lib/loggi/package_status.rb
@@ -9,7 +9,7 @@ module Loggi
       @status_display = options[:statusDisplay] || options[:status_display]
       @detailed_status_display = options[:detailedStatusDisplay] || options[:detailed_status_display]
       @status_code = options[:statusCode] || options[:status_code]
-      @updated = Time.parse(options[:updated]) if options[:updated]
+      @updated = ActiveSupport::TimeZone['America/Sao_Paulo'].parse(options[:updated]) if options[:updated]
     end
   end
 end

--- a/lib/loggi/version.rb
+++ b/lib/loggi/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Loggi
-  VERSION = '0.5.0'
+  VERSION = '0.6.0'
 end

--- a/spec/factories/package_status.rb
+++ b/spec/factories/package_status.rb
@@ -8,6 +8,6 @@ FactoryBot.define do
     status_display { 'Não iniciada' }
     detailed_status_display { 'Agendado' }
     status_code { 1 }
-    updated { Time.parse('2019-04-24 13:48:33.126401') }
+    updated { ActiveSupport::TimeZone['America/Sao_Paulo'].parse('2019-04-24 13:48:33.126401') }
   end
 end

--- a/spec/lib/loggi/package_status_spec.rb
+++ b/spec/lib/loggi/package_status_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Loggi::PackageStatus, type: :model do
         expect(subject.status_display).to eq('Não iniciada')
         expect(subject.detailed_status_display).to eq('Agendado')
         expect(subject.status_code).to eq(1)
-        expect(subject.updated).to eq(Time.parse('2019-04-24 13:48:33.126401'))
+        expect(subject.updated).to eq(ActiveSupport::TimeZone['America/Sao_Paulo'].parse('2019-04-24 13:48:33.126401'))
       end
     end
   end


### PR DESCRIPTION
Este PR conserta o problema em que em algumas localizações o `Time.parse` assume que o horário recebido é UTC. No caso das requisições da Loggi o horário recebido é o timezone de 'America/Sao_Paulo'.

Isto pode causar problemas em relação ao horário salvo nos apps em Rails, já que o `datetime` salvo sempre é UTC, logo caso o `Time.parse` assuma o timezone errado poderá ser salvo errado tbm no db.